### PR TITLE
Change how .env variable are imported

### DIFF
--- a/borg-backup/backup-borg-s3.sh
+++ b/borg-backup/backup-borg-s3.sh
@@ -6,7 +6,9 @@ if [ ! -f "${ENV_FILE}" ]; then
 	exit 1
 fi
 # Export env variables
-export $(cat $ENV_FILE | sed 's/#.*//g' | xargs)
+set -o allexport
+source .env
+set +o allexport
 
 # Name to give this backup within the borg repo
 BACKUP_NAME=backup-$(date +%Y-%m-%dT%H.%M)


### PR DESCRIPTION
The current method of importing .env variables doesn't allow for multiple folders to be backed up.
Example:
```
DOCKER_DIR="/home/john/abc /home/john/zyx"
```
The above does not work and the second path is ignored.

Using `set allexport` is a more robust way of importing env variables.